### PR TITLE
Fix color when decoding image 4444

### DIFF
--- a/src/main/java/com/fragmenterworks/ffxivextract/helpers/ImageDecoding.java
+++ b/src/main/java/com/fragmenterworks/ffxivextract/helpers/ImageDecoding.java
@@ -82,7 +82,7 @@ public final class ImageDecoding {
 		for (int y = 0; y < targetHeight; y++) {
 			for (int x = 0; x < targetWidth; x++) {
 				final int pixel = buffer.getShort() & 0xffff;
-				final int r = 255 - ((pixel & 0xF)) * 16;
+				final int r = 255 - ((pixel & 0xF)) * 16; //potential bug: red and blue may be inverted
 				final int g = 255 - ((pixel & 0xF0) >> 4) * 16;
 				final int b = 255 - ((pixel & 0xF00) >> 8) * 16;
 				final int a = 255 - ((pixel & 0xF000) >> 12) * 16;
@@ -107,7 +107,7 @@ public final class ImageDecoding {
 		buffer.position(offset);
 
 		int p = 0;
-		final int r = 0;
+		final int r = 0; //potential bug: red and blue may be inverted
 		final int g = 0;
 		final int b = 0;
 		switch (channel) {

--- a/src/main/java/com/fragmenterworks/ffxivextract/helpers/ImageDecoding.java
+++ b/src/main/java/com/fragmenterworks/ffxivextract/helpers/ImageDecoding.java
@@ -48,9 +48,9 @@ public final class ImageDecoding {
 		for (int y = 0; y < targetHeight; y++) {
 			for (int x = 0; x < targetWidth; x++) {
 				final int pixel = buffer.getShort() & 0xffff;
-				final int r = ((pixel & 0xF)) * 16;
+				final int b = ((pixel & 0xF)) * 16;
 				final int g = ((pixel & 0xF0) >> 4) * 16;
-				final int b = ((pixel & 0xF00) >> 8) * 16;
+				final int r = ((pixel & 0xF00) >> 8) * 16;
 				final int a = ((pixel & 0xF000) >> 12) * 16;
 				p += 2;
 				img.setRGB(x, y, new Color(r, g, b, a).getRGB());


### PR DESCRIPTION
I'm guessing the same issue applies to `decodeImage4444split1channel` and `decodeImage4444split` in the same file, but I couldn't find a texture using those to test, so I didn't touch them.