### PR TITLE
Fix file path handling on Unix-like systems

### DIFF
--- a/src/main/java/com/fragmenterworks/ffxivextract/gui/FileManagerWindow.java
+++ b/src/main/java/com/fragmenterworks/ffxivextract/gui/FileManagerWindow.java
@@ -1066,7 +1066,7 @@ public class FileManagerWindow extends JFrame implements TreeSelectionListener, 
 
                             for (int l = 0; l < (tempView.getNumLangs()); l++) {
 
-                                String path = lastSaveLocation.getCanonicalPath() + "\\" + folderName + "\\" + fileName;
+                                String path = lastSaveLocation.getCanonicalPath() + File.separator + folderName + File.separator + fileName;
 
                                 File mkDirPath = new File(path);
                                 mkDirPath.getParentFile().mkdirs();
@@ -1098,7 +1098,7 @@ public class FileManagerWindow extends JFrame implements TreeSelectionListener, 
 
                                 fileName = exhName;
 
-                                path = lastSaveLocation.getCanonicalPath() + "\\" + folderName + "\\" + fileName;
+                                path = lastSaveLocation.getCanonicalPath() + File.separator + folderName + File.separator + fileName;
 
                                 File mkDirPath = new File(path);
                                 mkDirPath.getParentFile().mkdirs();
@@ -1110,7 +1110,7 @@ public class FileManagerWindow extends JFrame implements TreeSelectionListener, 
                         } else if (extension.equals(".obj")) {
                             Model model = new Model(folderName + "/" + fileName, indexFile, data, indexFile.getEndian());
 
-                            String path = lastSaveLocation.getCanonicalPath() + "\\" + folderName + "\\" + fileName;
+                            String path = lastSaveLocation.getCanonicalPath() + File.separator + folderName + File.separator + fileName;
 
                             File mkDirPath = new File(path);
                             mkDirPath.getParentFile().mkdirs();
@@ -1141,7 +1141,7 @@ public class FileManagerWindow extends JFrame implements TreeSelectionListener, 
                                     extension = ".vs.cso";
                                     String path = lastSaveLocation.getCanonicalPath();
 
-                                    path = lastSaveLocation.getCanonicalPath() + "\\" + folderName + "\\" + fileName;
+                                    path = lastSaveLocation.getCanonicalPath() + File.separator + folderName + File.separator + fileName;
 
                                     File mkDirPath = new File(path);
                                     mkDirPath.getParentFile().mkdirs();
@@ -1155,7 +1155,7 @@ public class FileManagerWindow extends JFrame implements TreeSelectionListener, 
                                     extension = ".ps.cso";
                                     String path = lastSaveLocation.getCanonicalPath();
 
-                                    path = lastSaveLocation.getCanonicalPath() + "\\" + folderName + "\\" + fileName;
+                                    path = lastSaveLocation.getCanonicalPath() + File.separator + folderName + File.separator + fileName;
 
                                     File mkDirPath = new File(path);
                                     mkDirPath.getParentFile().mkdirs();
@@ -1194,7 +1194,7 @@ public class FileManagerWindow extends JFrame implements TreeSelectionListener, 
 
                                 String path = lastSaveLocation.getCanonicalPath();
 
-                                path = lastSaveLocation.getCanonicalPath() + "\\" + folderName + "\\" + fileName;
+                                path = lastSaveLocation.getCanonicalPath() + File.separator + folderName + File.separator + fileName;
 
                                 File mkDirPath = new File(path);
                                 mkDirPath.getParentFile().mkdirs();
@@ -1220,7 +1220,7 @@ public class FileManagerWindow extends JFrame implements TreeSelectionListener, 
                     if (!doConvert)
                         extension = "";
 
-                    String path = lastSaveLocation.getCanonicalPath() + "\\" + folderName + "\\" + fileName;
+                    String path = lastSaveLocation.getCanonicalPath() + File.separator + folderName + File.separator + fileName;
 
                     File mkDirPath = new File(path);
                     mkDirPath.getParentFile().mkdirs();

--- a/src/main/java/com/fragmenterworks/ffxivextract/gui/modelviewer/ModelViewerWindow.java
+++ b/src/main/java/com/fragmenterworks/ffxivextract/gui/modelviewer/ModelViewerWindow.java
@@ -8,6 +8,7 @@ import com.fragmenterworks.ffxivextract.models.sqpack.index.SqPackIndexFile;
 
 import javax.swing.*;
 import java.awt.*;
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
@@ -72,7 +73,10 @@ public class ModelViewerWindow extends JFrame {
         protected Void doInBackground() {
             try {
                 dialog.nextFile(0, "0a0000");
-                exdIndexFile = SqPackIndexFile.read(getSqpackPath() + "\\game\\sqpack\\ffxiv\\0a0000.win32.index");
+                exdIndexFile = SqPackIndexFile.read(
+                    getSqpackPath() + File.separator +
+                            "game" + File.separator + "sqpack" + File.separator + "ffxiv" + File.separator + "0a0000.win32.index"
+                );
                 dialog.nextFile(1, "040000");
                 modelIndexFile = exdIndexFile.getIndexForIdFromSameRepo(0x040000);
                 dialog.nextFile(2, "010000");

--- a/src/main/java/com/fragmenterworks/ffxivextract/gui/outfitter/OutfitterWindow.java
+++ b/src/main/java/com/fragmenterworks/ffxivextract/gui/outfitter/OutfitterWindow.java
@@ -8,6 +8,7 @@ import com.fragmenterworks.ffxivextract.models.EXHF_File;
 import com.fragmenterworks.ffxivextract.models.sqpack.index.SqPackIndexFile;
 
 import javax.swing.*;
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
@@ -68,7 +69,10 @@ public class OutfitterWindow extends JFrame {
         protected Void doInBackground() {
             try {
                 dialog.nextFile(0, "0a0000");
-                exdIndexFile = SqPackIndexFile.read(getSqpackPath() + "\\game\\sqpack\\ffxiv\\0a0000.win32.index");
+                exdIndexFile = SqPackIndexFile.read(
+                    getSqpackPath() + File.separator +
+                            "game" + File.separator + "sqpack" + File.separator + "ffxiv" + File.separator + "0a0000.win32.index"
+                );
                 dialog.nextFile(1, "040000");
                 modelIndexFile = exdIndexFile.getIndexForIdFromSameRepo(0x040000);
                 dialog.nextFile(2, "Loading initial models...");

--- a/src/main/java/com/fragmenterworks/ffxivextract/helpers/FileTools.java
+++ b/src/main/java/com/fragmenterworks/ffxivextract/helpers/FileTools.java
@@ -73,8 +73,8 @@ public class FileTools {
             sqPakPath += File.separator;
         }
 
-        if (!sqPakPath.endsWith("\\game\\sqpack\\ffxiv\\")) {
-            sqPakPath += "\\game\\sqpack\\ffxiv\\";
+        if (!sqPakPath.endsWith(File.separator + "game" + File.separator + "sqpack" + File.separator + "ffxiv" + File.separator)) {
+            sqPakPath += File.separator + "game" + File.separator + "sqpack" + File.separator + "ffxiv" + File.separator;
         }
 
         SqPackIndexFile index = null;


### PR DESCRIPTION
Unix-like operating systems (Linux, macOS, BSDs...) use the forward slash (`/`) as a path component separator character, while Windows canonically uses the backwards slash (`\`). Currently, the codebase has hardcoded this platform-specific character in several file path manipulation routines, which renders asset extraction difficult on Unix-like operating systems due to backslashes not delimiting subdirectories:

![Exception when extracting on a Linux system](https://github.com/goaaats/ffxiv-explorer-fork/assets/7822554/df7efdc4-5a22-4b0d-904a-d5df5e549b70)

These changes fix that portability problem by using `File.separator` instead, which is guaranteed by the JVM to resolve to the appropriate separator character for the running environment. Windows users cannot be affected by this change, as `File.separator` resolves to the backwards slash there.